### PR TITLE
Fix component manager dependencies

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -26,12 +26,12 @@ dependencies:
   idf: ">=5.0.0"
 
   # ESP-IDF peripheral driver component (public → users link against it too)
-  espressif/driver: "*"
+  idf::driver: "*"
 
   # Core system libs used privately inside hf-hal
-  freertos: "*"
-  hal: "*"
-  esp_timer: "*"
+  idf::freertos: "*"
+  idf::hal: "*"
+  idf::esp_timer: "*"
 
 # ─── Packaging rules – keep download size minimal ────────────────────────────
 files:


### PR DESCRIPTION
## Summary
- fix manifest so build uses built-in IDF components

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ba4a5858483288c0dfaa040b060c9