### PR TITLE
Document EXTRA_COMPONENT_DIRS usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ cmake_minimum_required(VERSION 3.16)
 
 set(HF_HAL_ROOT ${CMAKE_CURRENT_LIST_DIR})
 
+# Expose optional WS2812 driver so its headers are available when the HAL is
+# consumed as a component. The driver lives under utils-and-drivers and is
+# treated as an extra component to keep the HAL self-contained.
+list(APPEND EXTRA_COMPONENT_DIRS "${HF_HAL_ROOT}/utils-and-drivers/hf-core-drivers/external/hf-ws2812-rmt-driver")
+
 #
 # ─── 1 · Locate all implementation files (skip docs, examples, tests) ──────────
 #
@@ -52,8 +57,7 @@ idf_component_register(
     # PUBLIC deps: anything the *application* must also link against.
     # (change to taste – these are the most common for a HAL).
     #
-    REQUIRES      driver freertos
-    #
+    REQUIRES      driver freertos hf-ws2812-rmt-driver
     # PRIVATE deps: used only while building this lib.
     #
     PRIV_REQUIRES hal esp_timer

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # hf-hal
 Contains the hal layer - as used in the HardFOC controller
+
+## WS2812 Driver Integration
+
+The HAL now pulls in the optional `hf-ws2812-rmt-driver` component automatically
+via `EXTRA_COMPONENT_DIRS`. When this repository is used as a component the
+driver's headers (such as `ws2812_cpp.hpp`) are available without any extra
+configuration.
+
+If you need to override the path, set `EXTRA_COMPONENT_DIRS` before running
+`idf.py`:
+
+```
+export EXTRA_COMPONENT_DIRS=$PWD/utils-and-drivers/hf-core-drivers/external/hf-ws2812-rmt-driver
+```


### PR DESCRIPTION
## Summary
- document how to point EXTRA_COMPONENT_DIRS at the WS2812 driver
- automatically add the WS2812 driver path from CMakeLists.txt
- fix ws2812 driver path in build