### PR TITLE
Add PCAL95555 GPIO wrapper

### DIFF
--- a/component-handler/AdcHandler.h
+++ b/component-handler/AdcHandler.h
@@ -1,0 +1,117 @@
+#ifndef COMPONENT_HANDLER_ADC_HANDLER_H_
+#define COMPONENT_HANDLER_ADC_HANDLER_H_
+
+#include "utils-and-drivers/hf-core-drivers/internal/hf-internal-interface-wrap/inc/BaseAdc.h"
+#include <array>
+#include <string_view>
+
+/**
+ * @file AdcHandler.h
+ * @brief Aggregates multiple ADC sources and provides named channel access.
+ *
+ * Use this helper to register ADC channels from various drivers derived from
+ * BaseAdc. Channels can then be read by name without worrying about which
+ * ADC instance owns them.
+ */
+template <std::size_t N> class AdcHandler {
+public:
+  struct ChannelInfo {
+    std::string_view name; ///< Logical name
+    BaseAdc &adc;          ///< Reference to ADC driver
+    uint8_t channel;       ///< Hardware channel number
+  };
+
+  /** Access the singleton instance. */
+  static AdcHandler &Instance() noexcept {
+    static AdcHandler inst;
+    return inst;
+  }
+
+  AdcHandler(const AdcHandler &) = delete;
+  AdcHandler &operator=(const AdcHandler &) = delete;
+
+  /**
+   * @brief Register a channel with a name.
+   * @param name Logical channel name.
+   * @param adc Reference to a BaseAdc derived driver.
+   * @param channel Underlying ADC channel number.
+   * @return true on success, false if the handler is full.
+   */
+  bool RegisterChannel(std::string_view name, BaseAdc &adc,
+                       uint8_t channel) noexcept;
+
+  /**
+   * @brief Read channel voltage.
+   */
+  BaseAdc::AdcErr ReadChannelV(std::string_view name, float &v,
+                               uint8_t samples = 1,
+                               uint32_t delay_ms = 0) noexcept;
+
+  /**
+   * @brief Read channel count.
+   */
+  BaseAdc::AdcErr ReadChannelCount(std::string_view name, uint32_t &count,
+                                   uint8_t samples = 1,
+                                   uint32_t delay_ms = 0) noexcept;
+
+  /**
+   * @brief Read channel count and voltage.
+   */
+  BaseAdc::AdcErr ReadChannel(std::string_view name, uint32_t &count, float &v,
+                              uint8_t samples = 1,
+                              uint32_t delay_ms = 0) noexcept;
+
+private:
+  AdcHandler() = default;
+
+  ChannelInfo *Find(std::string_view name) noexcept {
+    for (std::size_t i = 0; i < count_; ++i)
+      if (channels_[i].name == name)
+        return &channels_[i];
+    return nullptr;
+  }
+
+  std::array<ChannelInfo, N> channels_{};
+  std::size_t count_ = 0;
+};
+
+template <std::size_t N>
+bool AdcHandler<N>::RegisterChannel(std::string_view name, BaseAdc &adc,
+                                    uint8_t channel) noexcept {
+  if (count_ >= N)
+    return false;
+  channels_[count_++] = {name, adc, channel};
+  return true;
+}
+
+template <std::size_t N>
+BaseAdc::AdcErr AdcHandler<N>::ReadChannelV(std::string_view name, float &v,
+                                            uint8_t samples,
+                                            uint32_t delay_ms) noexcept {
+  auto info = Find(name);
+  if (!info)
+    return BaseAdc::AdcErr::ADC_ERR_CHANNEL_NOT_FOUND;
+  return info->adc.ReadChannelV(info->channel, v, samples, delay_ms);
+}
+
+template <std::size_t N>
+BaseAdc::AdcErr
+AdcHandler<N>::ReadChannelCount(std::string_view name, uint32_t &count,
+                                uint8_t samples, uint32_t delay_ms) noexcept {
+  auto info = Find(name);
+  if (!info)
+    return BaseAdc::AdcErr::ADC_ERR_CHANNEL_NOT_FOUND;
+  return info->adc.ReadChannelCount(info->channel, count, samples, delay_ms);
+}
+
+template <std::size_t N>
+BaseAdc::AdcErr
+AdcHandler<N>::ReadChannel(std::string_view name, uint32_t &count, float &v,
+                           uint8_t samples, uint32_t delay_ms) noexcept {
+  auto info = Find(name);
+  if (!info)
+    return BaseAdc::AdcErr::ADC_ERR_CHANNEL_NOT_FOUND;
+  return info->adc.ReadChannel(info->channel, count, v, samples, delay_ms);
+}
+
+#endif // COMPONENT_HANDLER_ADC_HANDLER_H_

--- a/component-handler/GpioHandler.h
+++ b/component-handler/GpioHandler.h
@@ -1,0 +1,67 @@
+#ifndef COMPONENT_HANDLER_GPIO_HANDLER_H_
+#define COMPONENT_HANDLER_GPIO_HANDLER_H_
+
+#include "utils-and-drivers/hf-core-drivers/internal/hf-internal-interface-wrap/inc/DigitalGpio.h"
+#include <array>
+#include <string_view>
+
+/**
+ * @file GpioHandler.h
+ * @brief Aggregates multiple DigitalGpio instances by name.
+ *
+ * The handler stores references to GPIO drivers known at compile time.  Use
+ * RegisterPin() during initialization to map a human readable name to each
+ * DigitalGpio reference.  Pins can later be retrieved by name for reading or
+ * writing without caring which chip provides the actual GPIO.
+ */
+template <std::size_t N> class GpioHandler {
+public:
+  struct PinInfo {
+    std::string_view name; ///< Logical pin name
+    DigitalGpio &gpio;     ///< Reference to the GPIO object
+  };
+
+  /**
+   * @brief Access the singleton instance.
+   */
+  static GpioHandler &Instance() noexcept {
+    static GpioHandler inst;
+    return inst;
+  }
+
+  GpioHandler(const GpioHandler &) = delete;
+  GpioHandler &operator=(const GpioHandler &) = delete;
+
+  /**
+   * @brief Register a GPIO reference with a name.
+   * @param name Logical pin name.
+   * @param gpio Reference to a DigitalGpio derived object.
+   * @return true if successfully registered, false if full.
+   */
+  bool RegisterPin(std::string_view name, DigitalGpio &gpio) noexcept {
+    if (count_ >= N)
+      return false;
+    pins_[count_++] = {name, gpio};
+    return true;
+  }
+
+  /**
+   * @brief Retrieve a pointer to a registered pin by name.
+   * @return Pointer to DigitalGpio or nullptr if not found.
+   */
+  DigitalGpio *GetPin(std::string_view name) noexcept {
+    for (std::size_t i = 0; i < count_; ++i) {
+      if (pins_[i].name == name)
+        return &pins_[i].gpio;
+    }
+    return nullptr;
+  }
+
+private:
+  GpioHandler() = default;
+
+  std::array<PinInfo, N> pins_{}; ///< Compile-time array of pin info
+  std::size_t count_ = 0;         ///< Number of registered pins
+};
+
+#endif // COMPONENT_HANDLER_GPIO_HANDLER_H_

--- a/component-handler/Pcal95555Gpio.h
+++ b/component-handler/Pcal95555Gpio.h
@@ -1,0 +1,132 @@
+#ifndef COMPONENT_HANDLER_PCAL95555GPIO_H_
+#define COMPONENT_HANDLER_PCAL95555GPIO_H_
+
+#include "component-handler/GpioHandler.h"
+#include "utils-and-drivers/hf-core-drivers/external/hf-pcal95555-driver/src/pacl95555.hpp"
+#include "utils-and-drivers/hf-core-drivers/internal/hf-internal-interface-wrap/inc/DigitalGpio.h"
+#include "utils-and-drivers/hf-core-drivers/internal/hf-internal-interface-wrap/inc/SfI2cBus.h"
+#include <array>
+#include <string_view>
+
+/**
+ * @file Pcal95555Gpio.h
+ * @brief Wrapper classes to integrate the PCAL95555 GPIO expander with the
+ *        internal SfI2cBus driver and GpioHandler aggregation.
+ */
+
+/**
+ * @class SfPcal95555Bus
+ * @brief Adapter implementing PACL95555::i2cBus using SfI2cBus for
+ *        thread-safe transfers.
+ */
+class SfPcal95555Bus : public PACL95555::i2cBus {
+public:
+  explicit SfPcal95555Bus(SfI2cBus &bus) noexcept : bus_(bus) {}
+
+  bool write(uint8_t addr, uint8_t reg, const uint8_t *data,
+             size_t len) override {
+    std::array<uint8_t, 9> buf{}; // reg + up to 8 bytes
+    if (len > buf.size() - 1)
+      return false;
+    buf[0] = reg;
+    for (size_t i = 0; i < len; ++i)
+      buf[i + 1] = data[i];
+    return bus_.Write(addr, buf.data(), len + 1, 1000);
+  }
+
+  bool read(uint8_t addr, uint8_t reg, uint8_t *data, size_t len) override {
+    return bus_.WriteRead(addr, &reg, 1, data, len, 1000);
+  }
+
+private:
+  SfI2cBus &bus_;
+};
+
+/**
+ * @class Pcal95555Pin
+ * @brief Represents a single PCAL95555 GPIO as a DigitalGpio instance.
+ */
+class Pcal95555Pin : public DigitalGpio {
+public:
+  Pcal95555Pin(PACL95555 &chip, uint8_t index, ActiveState act,
+               PACL95555::GPIODir dir = PACL95555::GPIODir::Input) noexcept
+      : DigitalGpio(GPIO_NUM_NC, act), chip_(chip), index_(index), dir_(dir) {}
+
+  bool Initialize() noexcept override {
+    return chip_.setPinDirection(index_, dir_);
+  }
+
+  bool SetActive() noexcept {
+    return EnsureInitialized() && chip_.writePin(index_, true ^ IsActiveLow());
+  }
+
+  bool SetInactive() noexcept {
+    return EnsureInitialized() && chip_.writePin(index_, false ^ IsActiveLow());
+  }
+
+  bool Toggle() noexcept {
+    return EnsureInitialized() && chip_.togglePin(index_);
+  }
+
+  bool IsActive() noexcept {
+    if (!EnsureInitialized())
+      return false;
+    bool level = chip_.readPin(index_);
+    return IsActiveHigh() ? level : !level;
+  }
+
+private:
+  PACL95555 &chip_;
+  uint8_t index_;
+  PACL95555::GPIODir dir_;
+};
+
+/**
+ * @class Pcal95555Chip
+ * @brief Helper owning a PCAL95555 device and exposing its pins.
+ */
+class Pcal95555Chip {
+public:
+  static constexpr std::size_t kPinCount = 16;
+
+  Pcal95555Chip(SfI2cBus &bus, uint8_t addr)
+      : adapter_(bus), device_(&adapter_, addr),
+        pins_{
+            Pcal95555Pin(device_, 0, ActiveState::High),
+            Pcal95555Pin(device_, 1, ActiveState::High),
+            Pcal95555Pin(device_, 2, ActiveState::High),
+            Pcal95555Pin(device_, 3, ActiveState::High),
+            Pcal95555Pin(device_, 4, ActiveState::High),
+            Pcal95555Pin(device_, 5, ActiveState::High),
+            Pcal95555Pin(device_, 6, ActiveState::High),
+            Pcal95555Pin(device_, 7, ActiveState::High),
+            Pcal95555Pin(device_, 8, ActiveState::High),
+            Pcal95555Pin(device_, 9, ActiveState::High),
+            Pcal95555Pin(device_, 10, ActiveState::High),
+            Pcal95555Pin(device_, 11, ActiveState::High),
+            Pcal95555Pin(device_, 12, ActiveState::High),
+            Pcal95555Pin(device_, 13, ActiveState::High),
+            Pcal95555Pin(device_, 14, ActiveState::High),
+            Pcal95555Pin(device_, 15, ActiveState::High),
+        } {}
+
+  template <std::size_t N>
+  bool RegisterAll(GpioHandler<N> &handler,
+                   const std::array<std::string_view, kPinCount> &names) {
+    bool ok = true;
+    for (std::size_t i = 0; i < kPinCount; ++i) {
+      ok &= handler.RegisterPin(names[i], pins_[i]);
+    }
+    return ok;
+  }
+
+  PACL95555 &Device() noexcept { return device_; }
+  Pcal95555Pin &Pin(std::size_t i) noexcept { return pins_[i]; }
+
+private:
+  SfPcal95555Bus adapter_;
+  PACL95555 device_;
+  std::array<Pcal95555Pin, kPinCount> pins_;
+};
+
+#endif // COMPONENT_HANDLER_PCAL95555GPIO_H_


### PR DESCRIPTION
## Summary
- add a thread-safe I2C bus adapter for the PCAL95555 driver
- expose each PCAL95555 pin as a `DigitalGpio`
- provide helper to register all pins in `GpioHandler`
- make `GpioHandler` and `AdcHandler` singletons storing compile-time arrays of references
- store ADC drivers as references rather than pointers